### PR TITLE
Configure percentage of different pixels allowed to pass test

### DIFF
--- a/backstop-settings.js
+++ b/backstop-settings.js
@@ -69,4 +69,5 @@ module.exports = {
   asyncCompareLimit: 50, // default: 50
   debug: false,
   debugWindow: false,
+  misMatchThreshold: 0,
 };


### PR DESCRIPTION
Der [default von BackstopJS](https://github.com/garris/BackstopJS#changing-test-sensitivity) ist `0.1%`, was schon recht viel zulässt.