### PR TITLE
Add ad tests for ZOE

### DIFF
--- a/engine_scripts/appUserAgent.js
+++ b/engine_scripts/appUserAgent.js
@@ -1,0 +1,4 @@
+//
+module.exports = async page => {
+  await page.setUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E216 ZONApp/iOS/2.1');
+};

--- a/scenarios/zon/centerpage/ads.js
+++ b/scenarios/zon/centerpage/ads.js
@@ -1,0 +1,26 @@
+const scenarios = [
+  {
+    url: '/zeit-online/centerpage/index?ad-debug',
+    selectors: ['.ad-container[data-type="desktop"]'],
+    selectorExpansion: true,
+    expect: 13,
+    viewports: ['desktop', 'tablet']
+  },
+  {
+    url: '/zeit-online/centerpage/index?ad-debug',
+    selectors: ['.ad-container[data-type="mobile"]'],
+    selectorExpansion: true,
+    expect: 10,
+    viewports: ['mobile']
+  },
+  {
+    url: '/zeit-online/centerpage/index?ad-debug',
+    selectors: ['.ad-container--in-app[data-type="mobile"]'],
+    selectorExpansion: true,
+    expect: 10,
+    onBeforeScript: 'appUserAgent.js',
+    viewports: ['mobile', 'tablet']
+  },
+];
+
+module.exports = scenarios;

--- a/scenarios/zon/centerpage/ads.js
+++ b/scenarios/zon/centerpage/ads.js
@@ -21,6 +21,102 @@ const scenarios = [
     onBeforeScript: 'appUserAgent.js',
     viewports: ['mobile', 'tablet']
   },
+  {
+    label: 'browser',
+    url: '/zeit-online/centerpage/index?ad-debug',
+    selectors: ['document']
+  },
+  {
+    label: 'app-webview',
+    url: '/zeit-online/centerpage/index?ad-debug',
+    onBeforeScript: 'appUserAgent.js',
+    selectors: ['document'],
+    viewports: ['mobile', 'tablet']
+  },
+  {
+    label: 'browser',
+    url: '/zeit-online/centerpage/index-with-classic?ad-debug',
+    selectors: ['document']
+  },
+  {
+    label: 'app-webview',
+    url: '/zeit-online/centerpage/index-with-classic?ad-debug',
+    onBeforeScript: 'appUserAgent.js',
+    selectors: ['document'],
+    viewports: ['mobile', 'tablet']
+  },
+  {
+    label: 'browser',
+    url: '/zeit-online/centerpage/centerpage?ad-debug',
+    selectors: ['document']
+  },
+  {
+    label: 'app-webview',
+    url: '/zeit-online/centerpage/centerpage?ad-debug',
+    onBeforeScript: 'appUserAgent.js',
+    selectors: ['document'],
+    viewports: ['mobile', 'tablet']
+  },
+  {
+    label: 'browser',
+    url: '/zeit-online/centerpage/teaser-to-wochenmarkt?ad-debug',
+    selectors: ['document']
+  },
+  {
+    label: 'app-webview',
+    url: '/zeit-online/centerpage/teaser-to-wochenmarkt?ad-debug',
+    onBeforeScript: 'appUserAgent.js',
+    selectors: ['document'],
+    viewports: ['mobile', 'tablet']
+  },
+  {
+    label: 'browser',
+    url: '/thema/index?ad-debug',
+    selectors: ['document']
+  },
+  {
+    label: 'app-webview',
+    url: '/thema/index?ad-debug',
+    onBeforeScript: 'appUserAgent.js',
+    selectors: ['document'],
+    viewports: ['mobile', 'tablet']
+  },
+  {
+    label: 'browser',
+    url: '/thema/autotopic?ad-debug',
+    selectors: ['document']
+  },
+  {
+    label: 'app-webview',
+    url: '/thema/autotopic?ad-debug',
+    onBeforeScript: 'appUserAgent.js',
+    selectors: ['document'],
+    viewports: ['mobile', 'tablet']
+  },
+  {
+    label: 'browser',
+    url: '/thema/manualtopic?ad-debug',
+    selectors: ['document']
+  },
+  {
+    label: 'app-webview',
+    url: '/thema/manualtopic?ad-debug',
+    onBeforeScript: 'appUserAgent.js',
+    selectors: ['document'],
+    viewports: ['mobile', 'tablet']
+  },
+  {
+    label: 'browser',
+    url: '/thema/jurastudium?ad-debug',
+    selectors: ['document']
+  },
+  {
+    label: 'app-webview',
+    url: '/thema/jurastudium?ad-debug',
+    onBeforeScript: 'appUserAgent.js',
+    selectors: ['document'],
+    viewports: ['mobile', 'tablet']
+  },
 ];
 
 module.exports = scenarios;


### PR DESCRIPTION
### Was macht dieser PR
Es werden einige Tests für Adplatzierungen hinzugefügt. Damit diese sinnvoll laufen, müssen in zeit.web die Feature-Toggle `third_party_modules` und `iqd` aktiviert werden (ich träume immer noch davon, das von _aussen_ bspw. per URL machen zu können, aber egal…)

### Was ist zu tun?
Ich hab's heute nicht mehr geschafft, die Tests durchlaufen zu lassen, aber das würde so funktionieren:
- Repo installieren wie in <https://github.com/ZeitOnline/test_visual_regression#readme> beschrieben
- diesen Branch auschecken
- Friedbert/zeit.web an den Start bringen, im Master-Branch bauen und bin/serve laufen lassen
- Referenz-Shot aufnehmen: `npm run reference -- --filter=zon::centerpage::ads`
- Friedbert/zeit.web an den Start bringen, im codecandies:ZOE/ZO-252-Branch bauen und bin/serve laufen lassen
- Test laufen lassen `npm run test -- --filter=zon::centerpage::ads`
- und sich dann überraschen lassen…